### PR TITLE
R11DT-1465: Add parent chain to onScriptError

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.7-outsystems.1",
   "license": "MIT",
   "volo": {
-    "url": "https://raw.github.com/requirejs/requirejs/{version}/require.js"
+    "url": "https://raw.github.com/outsystems/requirejs/{version}/require.js"
   },
   "main": "require.js",
   "scripts": {
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/requirejs/requirejs.git"
+    "url": "https://github.com/outsystems/requirejs.git"
   },
   "devDependencies": {
     "jscs": "^1.12.0",

--- a/require.js
+++ b/require.js
@@ -1723,7 +1723,8 @@ var requirejs, require, define;
              * Callback for script errors.
              */
             onScriptError: function (evt) {
-                var originalAttrId = attrId = getScriptData(evt).id;
+                var originalAttrId = getScriptData(evt).id;
+                var attrId = originalAttrId;
                 if (!hasPathFallback(originalAttrId)) {
                     var parents = [];
                     var matchFound;

--- a/require.js
+++ b/require.js
@@ -164,10 +164,11 @@ var requirejs, require, define;
      *
      * @returns {Error}
      */
-    function makeError(id, msg, err, requireModules) {
+    function makeError(id, msg, err, requireModules, parentModules) {
         var e = new Error(msg + '\nhttps://requirejs.org/docs/errors.html#' + id);
         e.requireType = id;
         e.requireModules = requireModules;
+        e.parentModules = parentModules;
         if (err) {
             e.originalError = err;
         }
@@ -1722,23 +1723,29 @@ var requirejs, require, define;
              * Callback for script errors.
              */
             onScriptError: function (evt) {
-                var data = getScriptData(evt);
-                if (!hasPathFallback(data.id)) {
+                var originalAttrId = attrId = getScriptData(evt).id;
+                if (!hasPathFallback(originalAttrId)) {
                     var parents = [];
-                    eachProp(registry, function(value, key) {
-                        if (key.indexOf('_@r') !== 0) {
-                            each(value.depMaps, function(depMap) {
-                                if (depMap.id === data.id) {
-                                    parents.push(key);
-                                    return true;
-                                }
-                            });
-                        }
-                    });
-                    return onError(makeError('scripterror', 'Script error for "' + data.id +
+                    var matchFound;
+                    do {
+                        matchFound = false;
+                        eachProp(registry, function(value, key) {
+                            if (key.indexOf('_@r') !== 0) {
+                                each(value.depMaps, function(depMap) {
+                                    if (depMap.id === attrId) {
+                                        parents.push(key);
+                                        attrId = key;
+                                        matchFound = true;
+                                        return true;
+                                    }
+                                });
+                            }
+                        });
+                    } while(matchFound);
+                    return onError(makeError('scripterror', 'Script error for "' + originalAttrId +
                                              (parents.length ?
                                              '", needed by: ' + parents.join(', ') :
-                                             '"'), evt, [data.id]));
+                                             '"'), evt, [originalAttrId], parents));
                 }
             }
         };

--- a/tests/all.js
+++ b/tests/all.js
@@ -210,6 +210,7 @@ doh.registerUrl("pluginErrorContinue", "../error/pluginErrorContinue.html", 8000
 doh.registerUrl("pluginErrorContinueLocal", "../error/pluginErrorContinueLocal.html", 8000);
 doh.registerUrl("defineErrorLocal", "../error/defineErrorLocal.html");
 doh.registerUrl("errorChild", "../error/errorChild.html");
+doh.registerUrl("errorDeepDependency", "../error/errorDeepDependency.html");
 
 
 doh.registerUrl("pathArray", "../pathArray/pathArray.html", 8000);

--- a/tests/error/onScriptError.html
+++ b/tests/error/onScriptError.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>require.js: Deep Dependency Error Catch Test</title>
+    <script type="text/javascript" src="../../require.js"></script>
+    <script type="text/javascript" src="../doh/runner.js"></script>
+    <script type="text/javascript" src="../doh/_browserRunner.js"></script>
+    <script type="text/javascript">
+        var master = new doh.Deferred();
+        var testSucceeded = false;
+        const moduleNameList = ['module1', 'module2', 'module3', 'nonExistingModule'];
+
+        function done() {
+            if (testSucceeded) {
+                master.callback(true);
+            }
+        }
+
+        function containsAllElements(arr1, arr2) {
+            return arr1.every(el => arr2.includes(el));
+        }
+        
+        // Define the module dependency chain
+        for(let i = 0; i < moduleNameList.length - 1; i++) {
+            define(moduleNameList[i], [moduleNameList[i + 1]], function(m) {
+                return {};
+            });
+        }
+
+        require([moduleNameList[0]], function (a) {
+        }, function (err) {
+            completeFailedChain = err.requireModules.concat(err.parentModules ?? []);
+            testSucceeded = containsAllElements(moduleNameList, completeFailedChain);
+        });
+
+        setTimeout(done, 500);
+
+        doh.register(
+            "errorDeepChild",
+            [
+                {
+                    name: "errorDeepChild",
+                    timeout: 1000,
+                    runTest: function () {
+                        return master;
+                    }
+                }
+            ]
+        );
+        doh.run();
+    </script>
+</head>
+<body>
+    <h1>require.js: Deep Dependency Error Catch Test</h1>
+    <p>When a module dependency throws an error or is missing, the complete dependency 
+        chain is added to the generated error.</p>
+    <p>Check console for messages</p>
+</body>
+</html>


### PR DESCRIPTION
### Context
This PR proposes changes to the `onScriptError` and `makerror` methods to include, in the generated error object, the file chain that depends on the failed file (i.e to include the file's parent chain).

Before the implementation, requirejs would only lookup for the direct parent and only log it in the error object. Now, we append the complete parent list, so we can later invalidate the whole parent chain to be requested/reloaded again.

As for tests, the new requirejs implementation was copied into my local platform and manually included in the `client-runtime-core` and `client-runtime` `node_modules` folders: No issues were found during runtime and while executing the repository test.