### PR TITLE
R11DT-1465: Changes the artifact output to match requirejs

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -30,14 +30,14 @@ var build=Task("Build")
     Information("Ending Build");
 });
 var tests = Task("Tests")
-	.Does(()=>
-	{	
+    .Does(()=>
+    {
         Information("Starting Tests");
         var conf = ParseJsonFromFile("package.json");
         if(conf["scripts"]["test"]!=null)
             NpmRunScript("test");
         Information("Ending Tests");
-	});
+    });
 
 var package = Task("Package")
     .Does(()=>
@@ -50,6 +50,7 @@ var package = Task("Package")
     });
     
 Task("Default")
+    .IsDependentOn("Build")
     .IsDependentOn("Package");
 
 RunTarget(target);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
       },
       "devDependencies": {
         "jscs": "^1.12.0",
-        "jshint": "^2.7.0"
+        "jshint": "^2.7.0",
+        "mkdirp": "^2.1.3",
+        "requirejs": "^2.3.6"
       }
     },
     "node_modules/ansi-regex": {
@@ -1169,23 +1171,29 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
+      "version": "1.2.7",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha1-2qHE2R9Qc5BDfGqLwBB45wAMTRg=",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/mkdirp/-/mkdirp-2.1.3.tgz",
+      "integrity": "sha1-sIP/N74Eb9PWVSRowfD/RMFUXR8=",
+      "dev": true,
+      "license": "MIT",
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mute-stream": {
@@ -1356,6 +1364,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/requirejs": {
+      "version": "2.3.6",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/requirejs/-/requirejs-2.3.6.tgz",
+      "integrity": "sha1-5Qk9lgHCgpJRJYwLlEXU0Z+p58k=",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "r_js": "bin/r.js",
+        "r.js": "bin/r.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/revalidator": {
@@ -1562,6 +1584,19 @@
       },
       "engines": {
         "node": ">= 0.6.4"
+      }
+    },
+    "node_modules/utile/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/uuid": {
@@ -2596,19 +2631,16 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha1-hjelt1nqDW6YcCz7OpKDMjyTr0Q=",
+      "version": "1.2.7",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha1-2qHE2R9Qc5BDfGqLwBB45wAMTRg=",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.6"
-      }
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/mkdirp/-/mkdirp-2.1.3.tgz",
+      "integrity": "sha1-sIP/N74Eb9PWVSRowfD/RMFUXR8=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -2727,6 +2759,12 @@
         "define-properties": "^1.1.3",
         "functions-have-names": "^1.2.2"
       }
+    },
+    "requirejs": {
+      "version": "2.3.6",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/requirejs/-/requirejs-2.3.6.tgz",
+      "integrity": "sha1-5Qk9lgHCgpJRJYwLlEXU0Z+p58k=",
+      "dev": true
     },
     "revalidator": {
       "version": "0.1.8",
@@ -2863,6 +2901,17 @@
         "mkdirp": "0.x.x",
         "ncp": "0.4.x",
         "rimraf": "2.x.x"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        }
       }
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "main": "require.js",
   "scripts": {
     "pretest": "jscs . && jshint require.js",
-    "bump": "node ./scripts/bump-version"
+    "bump": "node ./scripts/bump-version",
+    "build": "npm install && mkdirp ./bin && npm run copyfile",
+    "copyfile": "copy \"node_modules\\\\requirejs\\\\bin\\\\r.js\" \"bin\""
   },
   "repository": {
     "type": "git",
@@ -16,9 +18,15 @@
   },
   "devDependencies": {
     "jscs": "^1.12.0",
-    "jshint": "^2.7.0"
+    "jshint": "^2.7.0",
+    "mkdirp": "^2.1.3",
+    "requirejs": "^2.3.6"
   },
   "dependencies": {
     "uglify-js": "^3.17.1"
-  }
+  },
+  "files": [
+    "require.js",
+    "bin/r.js"
+  ]
 }


### PR DESCRIPTION
Currently, when we build the requirejs artifact, we are both missing the `r.js` file and including all the files from the outsystems' requiredjs repository.
The PR fixes this, so that when we import this outsystems' requirejs we have the same files as importing the normal requirejs.