### PR TITLE
R11DT-1467 Changes default requirejs path to the correct one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
       "dependencies": {
         "uglify-js": "^3.17.1"
       },
+      "bin": {
+        "r_js": "bin/r.js",
+        "r.js": "bin/r.js"
+      },
       "devDependencies": {
         "jscs": "^1.12.0",
         "jshint": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "volo": {
     "url": "https://raw.github.com/outsystems/requirejs/{version}/require.js"
   },
-  "main": "require.js",
+  "main": "./bin/r.js",
+  "bin": {
+    "r.js": "./bin/r.js",
+    "r_js": "./bin/r.js"
+  },
   "scripts": {
     "pretest": "jscs . && jshint require.js",
     "bump": "node ./scripts/bump-version",


### PR DESCRIPTION
This PR changes the package.json `main` to `./bin/r.js` since not only is this the correct one, but karma-requirejs expects this path as the main one.
It also adds the `bin` option since this is something present in the vanilla requirejs.